### PR TITLE
Configure magic to use OpenPDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ WORKDIR /home/ee431/git_magic
 RUN ./configure --prefix=/usr
 RUN make
 RUN make install
+ENV CAD_ROOT=/usr/lib/
 WORKDIR /home/ee431
 
 # Install XSchem
@@ -38,12 +39,21 @@ RUN make
 RUN make install
 WORKDIR /home/ee431
 
+# Install OpenPDK
 RUN git clone https://github.com/RTimothyEdwards/open_pdks.git git_open_pdks
 WORKDIR /home/ee431/git_open_pdks
 RUN ./configure --enable-sky130-pdk --with-sky130-variants=all --with-reference
 RUN make || true
 RUN make install
+ENV PDK_ROOT=/usr/local/share/pdk
 
+# Configure Magic with OpenPDK
+RUN ln -sf $PDK_ROOT/sky13A/libs.tech/magic/* $CAD_ROOT/magic/sys/
+RUN mkdir magic_template_project
+WORKDIR /home/ee431/magic_template_project
+RUN cp $PDK_ROOT/sky130A/libs.tech/magic/sky130A.magicrc .
+
+# Configure XSchem with OpenPDK
 WORKDIR /home/ee431
 COPY xschemrc /home/ee431/xschemrc
 RUN cp /usr/local/share/pdk/sky130A/libs.tech/xschem/xschemrc xschemrc2

--- a/README.md
+++ b/README.md
@@ -51,6 +51,20 @@ You might be logged out after the installation takes place. Simply log back in y
 ### Step 1: Enter the Container
 To run magic, navigate to the directory where it is installed eg. `cd ~/EE431_Toolchain` then run the following command to enter the container
 
-### Step 2: Launch Magic
-Once in the container, simply type `magic` and the program should start up with a gui.
+
+### Step 2: Create a Project
+A project template has been created for you and resides in the home directory, you can make a copy of this and place it in the `workspace/` directory with the following command:
+
+``` shell
+cp -R magic_template_project workspace/<project_name>
+```
+> [!CAUTION]
+> Anything you don't place in the `workspace/` directory will be deleted when you restart the container
+
+### Step 3: Start Magic
+Then you can cd into the new project and start magic with:
+
+``` shell
+magic -rcfile=sky130A.magicrc
+```
 


### PR DESCRIPTION
Created a new magic_template_project that contains the magic rcfile so people can copy this and create magic projects.
I also linked the PDK stuff into magic so it will use the libraries.