### PR TITLE
Specify platform in docker commands

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 
 fi
 
-docker pull fwilken/ee431_toolchain:v1.1s
+docker pull --platform linux/amd64 fwilken/ee431_toolchain:v1.1s
 if ! [ $? -eq 0 ]; then
     sudo groupadd docker || true
     sudo usermod -aG docker $USER

--- a/run.sh
+++ b/run.sh
@@ -13,7 +13,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     xhost +localhost
 
     docker run -it --rm \
-	--platform linux/amd64
+	--platform linux/amd64 \
         -v $(pwd)/workspace:/home/ee431/workspace:rw \
         -e DISPLAY=host.docker.internal:0 \
         -e "TERM=xterm-256color"\

--- a/run.sh
+++ b/run.sh
@@ -13,6 +13,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     xhost +localhost
 
     docker run -it --rm \
+	--platform linux/amd64
         -v $(pwd)/workspace:/home/ee431/workspace:rw \
         -e DISPLAY=host.docker.internal:0 \
         -e "TERM=xterm-256color"\


### PR DESCRIPTION
This is done to make the scripts run on ARM-based Macbooks. If you try to pull from docker without specifying a platform, it will complain it doesn't have a remote version that matches your architecture.