### PR TITLE
Install gvim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt update
 RUN apt install -y git ngspice tcl-tclreadline build-essential flex \
     bison libxpm-dev libgtk-3-dev gettext m4 tcsh csh libx11-dev tcl-dev \
     tk-dev libcairo2-dev libncurses-dev blt freeglut3-dev mesa-common-dev \
-    libgl1-mesa-dev libglu1-mesa-dev xterm
+    libgl1-mesa-dev libglu1-mesa-dev xterm gvim
 
 # Install Magic
 RUN git clone https://github.com/RTimothyEdwards/magic.git git_magic

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt update
 RUN apt install -y git ngspice tcl-tclreadline build-essential flex \
     bison libxpm-dev libgtk-3-dev gettext m4 tcsh csh libx11-dev tcl-dev \
     tk-dev libcairo2-dev libncurses-dev blt freeglut3-dev mesa-common-dev \
-    libgl1-mesa-dev libglu1-mesa-dev xterm gvim
+    libgl1-mesa-dev libglu1-mesa-dev xterm vim-gtk3
 
 # Install Magic
 RUN git clone https://github.com/RTimothyEdwards/magic.git git_magic


### PR DESCRIPTION
As mentioned in #7 gvim is a requirement to view netlists from within xschem. This PR apt installs it to the base image.